### PR TITLE
:Yankitute now uses :s with sub-replace

### DIFF
--- a/autoload/yankitute.vim
+++ b/autoload/yankitute.vim
@@ -1,33 +1,45 @@
+function! yankitute#execute(cmd, start, end, reg) abort
+  let [reg, cmd] = a:reg =~? '[a-z0-9"]' ? [a:reg, a:cmd] : ['"', a:reg . a:cmd]
+  let sep = strlen(cmd) ? cmd[0] : '/'
+	let [pat, s:replace, flags, join; _] = split(cmd[1:], '\v([^\\](\\\\)*\\)@<!%d' . char2nr(sep), 1) + ['', '', '', '']
 
-function! yankitute#yankWithPattern(cmd,fromLine,toLine,register)
-	let l:separator=a:cmd[0]
-	let l:cmdSplitted=split(a:cmd[1:],'\v([^\\](\\\\)*\\)@<!%d'.char2nr(l:separator),1)
-	let l:pattern=l:cmdSplitted[0]
-	let l:substitution=1<len(l:cmdSplitted) ? l:cmdSplitted[1] : ''
+  if pat != ''
+    let @/ = pat
+  endif
 
-	let l:flags=2<len(l:cmdSplitted) ? l:cmdSplitted[2] : ''
-	let l:allFlag=0<=stridx(l:flags,'g')
+  if s:replace == ''
+    let s:replace = '&'
+  endif
+  let is_sub_replace = s:replace =~ '^\\='
+  let fn = 'yankitute#' . (is_sub_replace ? 'eval' : 'gather')
 
-	let l:lines=getline(a:fromLine,a:toLine)
-	let l:yankedStrings=[]
-	for l:line in l:lines
-		let l:matchFrom=0
-		let l:match=matchstr(l:line,l:pattern)
-		while(!empty(l:match) && (0==l:matchFrom || l:allFlag))
-			let l:matchFrom=stridx(l:line,l:match,l:matchFrom)+max([len(l:match),1])
-			if(!empty(l:substitution))
-				call add(l:yankedStrings,substitute(l:match,l:pattern,l:substitution,''))
-			else
-				call add(l:yankedStrings,l:match)
-			endif
-			if(l:allFlag)
-				let l:match=matchstr(l:line,l:pattern,l:matchFrom)
-			endif
-		endwhile
-	endfor
-	if(3<len(l:cmdSplitted))
-		call setreg(a:register,join(l:yankedStrings,l:cmdSplitted[3]))
-	else
-		call setreg(a:register,join(l:yankedStrings,"\n").(empty(l:yankedStrings) ? '' : "\n"))
-	endif
+  let s:results = []
+  let v:errmsg = ''
+  try
+    silent execute a:start . ',' . a:end . 's' . sep . pat . sep . '\=' . fn . '()' . sep . 'n' . flags
+  catch
+    let v:errmsg = substitute(v:exception, '.*:\zeE\d\+:\s', '', '')
+    return 'echoerr v:errmsg'
+  endtry
+
+  let results = []
+  if is_sub_replace
+    let results = s:results
+  else
+    for m in s:results
+      call add(results, substitute(s:replace, '\v%(%(\\\\)*\\)@<!%(\\(\d)|(\&))', '\=get(m,submatch(1)=="&"?0:submatch(1))', 'g'))
+    endfor
+  endif
+  unlet s:results
+
+  call setreg(reg, join == '' ? results : join(results, join))
+  return ''
+endfunction
+
+function! yankitute#gather() abort
+  let s:results += [map(range(10), 'submatch(v:val)')]
+endfunction
+
+function! yankitute#eval() abort
+  call add(s:results, eval(s:replace[2:]))
 endfunction

--- a/autoload/yankitute.vim
+++ b/autoload/yankitute.vim
@@ -55,5 +55,5 @@ endfunction
 
 function! yankitute#eval() abort
   call add(s:results, eval(s:replace[2:]))
-  rfunction! yankitute#execute(cmd, start, end, reg) abort,function,function! yankitute#gather() abort,function,function! yankitute#eval() abort,functioneturn submatch(0)
+  return submatch(0)
 endfunction

--- a/plugin/yankitute.vim
+++ b/plugin/yankitute.vim
@@ -1,2 +1,6 @@
+if exists('g:loaded_yankitute') || &cp || v:version < 700
+  finish
+endif
+let g:loaded_yankitute = 1
 
-command! -nargs=1 -range -register Yankitute call yankitute#yankWithPattern(<q-args>,<line1>,<line2>,'<register>')
+command! -nargs=? -range -register Yankitute execute yankitute#execute(<q-args>, <line1>, <line2>, '<register>')


### PR DESCRIPTION
Use `:s` with a sub-replace gives the following benefits:
- more `:s_flags` can be handled e.g. `i` and `c`
- respects `'gdefault'`
- pattern can use `\zs` and `\ze`
- replacement can use sub-replacement aka `\=`
- provide error detection
