### PR TITLE
Allow for newlines to be added in the replacement

### DIFF
--- a/autoload/yankitute.vim
+++ b/autoload/yankitute.vim
@@ -61,6 +61,8 @@ function! yankitute#execute(cmd, start, end, reg) abort
         endfor
     endif
 
+    let l:results = s:expand_returns(l:results)
+
     let [l:join, type] = l:join == '' ? ["\n", 'l'] : [l:join, 'c']
     call setreg(l:reg, join(l:results, l:join), type)
     return ''
@@ -74,4 +76,12 @@ endfunction
 function! s:eval(results, replace) abort
     call add(a:results, eval(a:replace[2:]))
     return submatch(0)
+endfunction
+
+function! s:expand_returns(lst) abort
+  let arr = []
+  let pat = '\v%(%(\\\\)*\\)@<!%(\\r)'
+  call map(a:lst, 'split(v:val, pat)')
+  call map(copy(a:lst), 'extend(arr, v:val)')
+  return arr
 endfunction


### PR DESCRIPTION
Attempt to close #3 by splitting results on `\r` and then "flattening" the list.

Note: I am not sure this how I feel about allowing returns combined with the `j` (join) flag, but it feels correct this way.

My original fix for this issue was on my branch, PeterRincker/vim-yankitute/newlines, however my fork has diverged from the original so I created this branch specifically to merge cleanly.